### PR TITLE
Adds automated build of the environment needed to use this.

### DIFF
--- a/.github/workflows/repo2docker.yml
+++ b/.github/workflows/repo2docker.yml
@@ -1,0 +1,16 @@
+name: Build Container
+on: [pull_request, push]
+jobs:
+  build-image-without-pushing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout PR
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: test build
+      uses: jupyterhub/repo2docker-action@master
+      with:
+        NO_PUSH: 'true'
+        IMAGE_NAME: "hamelsmu/repo2docker-test"

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,6 @@
+name: hdf5zarr
+channels:
+  - conda-forge
+dependencies:
+  - hdf5>=1.10.5
+  - pip

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,2 @@
+HDF5_DIR=$CONDA_PREFIX pip install --no-binary=h5py git+https://github.com/h5py/h5py.git
+pip install git+https://github.com/catalystneuro/HDF5Zarr.git


### PR DESCRIPTION
I am back at it! I am still running into issues creating a consistentt environment where I can use this, even while attempting to follow the instructions in the README. So I thought that I would make a PR here and we can iterate on it. The PR uses [repo2docker](https://repo2docker.readthedocs.io/en/latest/) to build an image from a well-defined [specification](https://repo2docker.readthedocs.io/en/latest/specification.html). First, conda is used to build the environment from the `environment.yml` file. Then, the `postBuild` file is executed in bash. I also added a GitHub actions file that attempts (and in this case, fails) to build the environment based on the specification, I think that the CI might only kick into action once you merge this PR. But you can see the results of the automated build on another repo that I have been trying this out with. [This](https://github.com/learning-2-learn/hdf5zarr-experiments/runs/955024043?check_suite_focus=true#step:4:1409) is the step that currently fails to build. 