### PR TITLE
open_as_zarr function

### DIFF
--- a/hdf5zarr/hdf5zarr.py
+++ b/hdf5zarr/hdf5zarr.py
@@ -16,6 +16,7 @@ from xdrlib import Unpacker
 import struct
 from sys import stdout
 from warnings import warn
+from fsspec.implementations import local
 SYMLINK = '.link'
 
 
@@ -152,7 +153,7 @@ class HDF5Zarr(object):
                  collectattrs: bool = True, uri: str = None, hdf5group: str = None,
                  store: Union[MutableMapping, str, Path] = None, store_path: str = None,
                  store_mode: str = 'a', LRU: bool = False, LRU_max_size: int = 2**30,
-                 max_chunksize=2*2**20, driver: str = None, blocksize: int = 2**14, collectrefs: Union[bool, str, list] = None):
+                 max_chunksize=2*2**20, driver: str = None, blocksize: int = 2**15, collectrefs: Union[bool, str, list] = None):
 
         """
         Args:
@@ -286,11 +287,11 @@ class HDF5Zarr(object):
         # Access hdf5 file and create zarr hierarchy
         self.hdf5group = hdf5group
         self.filename = filename
-        if driver is None and not h5filename and (self.filename, str):
+        if driver is None and not h5filename and isinstance(self.filename, str):
             # checks filename file system with fsspec
             try:
                 fs, _, _ = fsspec.get_fs_token_paths(self.filename)
-                if not isinstance(fs, fsspec.implementations.local.LocalFileSystem):
+                if not isinstance(fs, local.LocalFileSystem):
                     cache_type = 'mmap'  # TO DO
                     self.filename = fs.open(self.filename, mode='rb', cache_type=cache_type, block_size=self.blocksize)
             except:

--- a/hdf5zarr/hdf5zarr.py
+++ b/hdf5zarr/hdf5zarr.py
@@ -14,6 +14,7 @@ from pathlib import PurePosixPath
 from zarr.util import json_dumps, json_loads
 from xdrlib import Unpacker
 import struct
+from sys import stdout
 SYMLINK = '.link'
 
 
@@ -113,7 +114,8 @@ numcodecs.register_codec(VLenHDF5String)
 class HDF5Zarr(object):
     """ class to create zarr structure for reading hdf5 files """
 
-    def __init__(self, filename: str, hdf5group: str = None,
+    def __init__(self, filename: str, hdf5obj: str = None, hdf5group: str = None,
+                 collectattrs: bool = True, uri: str = None,
                  store: Union[MutableMapping, str, Path] = None, store_path: str = None,
                  store_mode: str = 'a', LRU: bool = False, LRU_max_size: int = 2**30,
                  max_chunksize=2*2**20, driver: str = None):
@@ -123,6 +125,11 @@ class HDF5Zarr(object):
             filename:                    str or File-like object, file name string or File-like object to be read by zarr
             hdf5group:                   str, hdf5 group in hdf5 file to be read by zarr
                                          along with its children. default is the root group.
+            hdf5obj:                     same as hdf5group for accepting either dataset or group,
+                                         overrides hdf5group
+            collectattrs:                whether to collect attributes or not, default True
+            uri:                         set uri in zarr store,
+                                         overrides determining uri from filename
             store:                       collections.abc.MutableMapping or str, zarr store.
                                          if string path is passed, zarr.DirectoryStore
                                          is created at the given path, if None, zarr.MemoryStore is used
@@ -155,6 +162,12 @@ class HDF5Zarr(object):
             raise TypeError(f"Expected positive int or None for max_chunksize,\
                               recieved {max_chunksize}, type: {type(max_chunksize)}")
         self.max_chunksize = max_chunksize
+        if not isinstance(collectattrs, bool):
+            raise TypeError(f"Expected bool for collectattrs, recieved {type(collectattrs)}")
+        self.collectattrs = collectattrs
+        if uri is not None and not isinstance(uri, str):
+            raise TypeError(f"Expected str for uri, recieved {type(uri)}")
+        self.uri = uri
 
         # store and store_mode are passed through to zarr
         self.store_mode = store_mode
@@ -175,24 +188,31 @@ class HDF5Zarr(object):
 
         if hdf5group is not None and not isinstance(hdf5group, str):
             raise TypeError(f"Expected str for hdf5group, recieved {type(hdf5group)}")
+        if hdf5obj is not None:
+            if not isinstance(hdf5obj, str):
+                raise TypeError(f"Expected str for hdf5obj, recieved {type(hdf5obj)}")
+            hdf5group = hdf5obj
         if hdf5group is not None and store_path is None:
             self.store_path = hdf5group  # store_path is passed to zarr
         else:
             self.store_path = store_path
-        self.zgroup = zarr.open_group(self.store, mode=self.store_mode, path=self.store_path)
+        self.zgroup = zarr.open(self.store, mode=self.store_mode, path=self.store_path)
         if self.store is None:
             self.store = self.zgroup.store
 
         # FileChunkStore requires uri
-        if isinstance(filename, str):
+        if self.uri is None and isinstance(filename, str):
             self.uri = filename
         else:
             try:
                 self.uri = getattr(filename, 'path', None)
                 if self.uri is None:
                     self.uri = filename.name
+                if self.uri in (None, b'') or len(str(self.uri)) == 0:
+                    raise Exception
             except Exception:
-                self.uri = ''
+                warn('unable to determine uri. uri argument is not passed')
+                self.uri = str(filename)
 
         # Access hdf5 file and create zarr hierarchy
         self.hdf5group = hdf5group
@@ -212,7 +232,7 @@ class HDF5Zarr(object):
 
         # open zarr group
         store_mode_cons = 'r' if self.store_mode == 'r' else 'r+'
-        self.zgroup = zarr.open_group(self.store, mode=store_mode_cons, path=self.store_path, chunk_store=self.chunk_store)
+        self.zgroup = zarr.open(self.store, mode=store_mode_cons, path=self.store_path, chunk_store=self.chunk_store)
 
     def consolidate_metadata(self, metadata_key='.zmetadata'):
         '''
@@ -551,14 +571,19 @@ class HDF5Zarr(object):
           zgroup:     Zarr Group
         """
 
-        if (not isinstance(h5py_group, h5py.File) and (not isinstance(h5py_group, h5py.Group) or
-           not isinstance(self.file.get(h5py_group.name, getlink=True), h5py.HardLink))):
-            raise TypeError(f"{h5py_group} should be a h5py.File or h5py.Group as a h5py.HardLink")
+        if isinstance(h5py_group, (h5py.File, h5py.Dataset)):
+            h5py_group_name = h5py_group.name
+        elif isinstance(h5py_group, h5py.Group):
+            h5py_group_name = self.get_name(self.file, h5py_group.name)
+        else:
+            raise TypeError(f"{h5py_group} should be a h5py.File, h5py.Group or h5py.Dataset")
 
         if h5py.version.hdf5_version_tuple < (1, 10, 5):
             raise Exception(("HDF5Zarr requires h5py installed with minimum hdf5 version of 1.10.5,\n"
                              f"Current hdf5 version {h5py.version.hdf5_version},\n"
                              "h5py installation: https://h5py.readthedocs.io/en/stable/build.html#custom-installation"))
+
+        self._address_dict = self.store[reference_key] if reference_key in self.store else dict()
 
         def _get_address(name, info):
             obj = self.group[name]
@@ -577,32 +602,85 @@ class HDF5Zarr(object):
         FileChunkStore.obj_address_info(self.store, self._address_dict)
 
         def _visit_create_zarr_hierarchy(name, link_info):
-            obj = self.group[name]
+            if link_info.type == h5py.h5l.TYPE_EXTERNAL:
+                print(f"Object {name} is not processed: External Link")
+                return None
+            else:
+                obj = self.group[name]
 
-            # Datasets
-            if isinstance(obj, h5py.Dataset):
-                # TO DO, Soft Links #
-                if link_info.type == h5py.h5l.TYPE_EXTERNAL:
-                    print(f"Dataset {obj.name} is not processed: External Link")
-                    return None
+                if link_info.type == h5py.h5l.TYPE_HARD:
+                    # link_info pointing to hard links stores target address in link_info.u
+                    if link_info.u in self._address_dict and self._address_dict[link_info.u] != obj.name:
+                        warn("Overwriting object {objname} address present in zarr store")
+                    self._address_dict[link_info.u]=obj.name
 
-                self._create_zarr_hierarchy(obj, self.zgroup)
-            # Groups
-            elif isinstance(obj, h5py.Group):
-                if link_info.type == h5py.h5l.TYPE_EXTERNAL:
-                    print(f"Group {obj.name} is not processed: External Link")
-                    return None
+                # Datasets
+                if isinstance(obj, h5py.Dataset):
+                    self._create_zarr_hierarchy(obj, self.zgroup)
+                # Groups
+                elif isinstance(obj, h5py.Group):
+                    if obj.name not in self.zgroup or not isinstance(self.zgroup[obj.name], zarr.Group):
+                        zgroup_ = self.zgroup.create_group(obj.name, overwrite=True)
+                    else:
+                        zgroup_ = self.zgroup[obj.name]
+                    if link_info.type == h5py.h5l.TYPE_SOFT:
+                        zgroup_path = zgroup_.create_group(SYMLINK, overwrite=True)
+                        zgroup_path.attrs[obj.name] = self.file.get(obj.name, getlink=True).path
 
-                zgroup_ = self.zgroup.create_group(name, overwrite=True)
-                if link_info.type == h5py.h5l.TYPE_SOFT:
-                    zgroup_path = zgroup_.create_group(SYMLINK, overwrite=True)
-                    zgroup_path.attrs[obj.name] = self.file.get(obj.name, getlink=True).path
+                # attributes
+                if self.collectattrs:
+                    self.copy_attrs_data_to_zarr_store(obj, self.zgroup[obj.name])
 
-            self.copy_attrs_data_to_zarr_store(obj, self.zgroup[name])
+        if not isinstance(h5py_group, h5py.Dataset):
+            # add h5py_group address
+            targetpath = self.get_name(h5py_group, h5py_group.name)  # get absolute h5py_group name
+            objno = h5py.h5g.get_objinfo(h5py_group.id).objno
+            self._address_dict[objno[0]]=targetpath
 
-        # create zarr hierarchy
-        self.copy_attrs_data_to_zarr_store(self.group, self.zgroup)
-        self.file.id.links.visit(_visit_create_zarr_hierarchy, obj_name=bytes(self.group.name, encoding='utf-8'), info=True)
+            # create zarr hierarchy
+            self.file.id.links.visit(_visit_create_zarr_hierarchy, obj_name=bytes(h5py_group_name, encoding='utf-8'), info=True)
+            if self.collectattrs:
+                self.copy_attrs_data_to_zarr_store(self.group, self.zgroup)
+        else:
+            link_info = self.file.id.links.get_info(bytes(self.group.name, encoding='utf-8'))
+            # TO DO, Soft Links #
+            if link_info.type == h5py.h5l.TYPE_EXTERNAL:
+                raise Exception(f"Dataset {obj.name} is an External Link")
+
+            if link_info.type == h5py.h5l.TYPE_SOFT:
+                warn(f"Dataset {obj.name} is a Soft Link")
+
+            groupname = self.group.parent.name  # dataset parent name is passed to zarr as path
+            if groupname in self.zgroup:
+                dsetparent = self.zgroup[groupname]
+            else:
+                dsetparent = self.zgroup.create_group(groupname)
+            self._create_zarr_hierarchy(h5py_group, dsetparent)
+            self.zgroup = dsetparent[h5py_group.name]
+            if self.collectattrs:
+                self.copy_attrs_data_to_zarr_store(h5py_group, self.zgroup)
+
+    @staticmethod
+    def get_name(hobj, name):
+        # return a hardlink to name. name is relative to hobj
+        if name == '/':
+            return name
+        linkinfo = hobj.get(name, getlink=True)
+        if isinstance(linkinfo, h5py.HardLink):
+            return name
+        else:
+            while True:
+                if isinstance(linkinfo, h5py.SoftLink):
+                    name = linkinfo.path
+                    linkinfo = hobj.file.get(name, getlink=True)
+                elif isinstance(linkinfo, h5py.ExternalLink):
+                    raise TypeError(f"{name} refers to an External Link. file: {linkinfo.filename}: dataset {linkinfo.path}")
+                elif linkinfo is None:
+                    raise TypeError(f"{name} is not in {hobj.file}")
+                else:
+                    break
+
+        return name
 
     def _create_zarr_hierarchy(self, dset, zgroup):
         """  Scan hdf5 file and recursively create zarr attributes, groups and dataset structures for accessing data
@@ -945,7 +1023,7 @@ class FileChunkStore(MutableMapping):
             Store for hdf5 object address information
         address_loc : dict
             Dictionary with object addresses as keys and object names as values
-        obj_path: str
+        obj_name: str
             path of zarr object in store, default None
         """
         if 'source' not in address_loc:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,8 +27,8 @@ def pytest_addoption(parser):
         "--numsubgroup",
         action="store",
         type=int,
-        default=3,
-        help="number of runs testing hdf5group argument",
+        default=4,
+        help="number of runs testing hdf5group/hdf5obj argument",
     )
     parser.addoption(
         "--fkeep",

--- a/tests/test_hdf5zarr.py
+++ b/tests/test_hdf5zarr.py
@@ -344,7 +344,7 @@ class HDF5ZarrBase(object):
                 self.hobj = self.hfile[name]
                 self.zobj = self.zgroup[name.decode('utf-8')]
             else:
-                self.hobj = self.hfile[name]
+                self.hobj = self.hfile
                 self.zobj = self.zgroup
 
             hobj_info = h5py.h5g.get_objinfo(self.hobj.id)
@@ -487,9 +487,11 @@ class TestHDF5Zarr(HDF5ZarrBase):
             cls.file_list += cls.file_list[:num_files]*2
             cls.hdf5zarr_list += [None]*num_files*2
             for i in range(len(cls.file_list)-2*num_files, len(cls.file_list)-num_files):
-                cls.hdf5zarr_list[i] = HDF5Zarr(cls.file_list[i].filename, max_chunksize=1000)
+                max_chunksize = 1000 if not cls.hdf5files_option else 2**cls.srand.randint(14, 20)
+                cls.hdf5zarr_list[i] = HDF5Zarr(cls.file_list[i].filename, max_chunksize=max_chunksize)
             for i in range(len(cls.file_list)-num_files, len(cls.file_list)):
-                cls.hdf5zarr_list[i] = HDF5Zarr(cls.file_list[i].filename, max_chunksize=2**cls.srand.randint(10, 20))
+                max_chunksize = 2**cls.srand.randint(10, 20) if not cls.hdf5files_option else 2**cls.srand.randint(14, 20)
+                cls.hdf5zarr_list[i] = HDF5Zarr(cls.file_list[i].filename, max_chunksize=max_chunksize)
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_hdf5zarr.py
+++ b/tests/test_hdf5zarr.py
@@ -3,7 +3,7 @@ import numpy as np
 import tempfile
 import secrets
 import h5py
-from hdf5zarr import HDF5Zarr
+from hdf5zarr import HDF5Zarr, open_as_zarr
 import pytest
 import itertools
 
@@ -13,6 +13,12 @@ class HDF5ZarrBase(object):
     ##########################################
     #  basic tests                           #
     ##########################################
+
+    @pytest.mark.parametrize('visit_type', [None], ids=[""])
+    def test_open_as_zarr(self):
+        zgroup = open_as_zarr(self.hfile)
+        assert zgroup.store == self.zgroup.store
+        assert zgroup == self.zgroup
 
     @pytest.mark.parametrize('visit_type', [None], ids=[""])
     def test_consolidate_metadata(self):

--- a/tests/test_hdf5zarr.py
+++ b/tests/test_hdf5zarr.py
@@ -8,17 +8,29 @@ import pytest
 import itertools
 
 
-class HDF5ZarrBase(object):
+class TestHDF5Zarr(object):
+
+    @pytest.fixture(autouse=True)
+    def visit_files(self, request, filesbase, capsys):
+        # file number
+        fnum = request.node.callspec.params['fnum']
+
+        num_files = filesbase.num_files
+        file_list = filesbase.file_list
+        hdf5zarr_list = filesbase.hdf5zarr_list
+
+        self.hfile, self.hdf5zarr = file_list[fnum], hdf5zarr_list[fnum]
+        self.zgroup = self.hdf5zarr.zgroup
+        with capsys.disabled():
+            if self.hdf5zarr.max_chunksize is not None:
+                print("\n"+f"file: {self.hfile.file.filename}, obj: {self.hfile.name}  :".rjust(len(request.node.nodeid)), end = '')
+            else:
+                print("\n"+(f"file: {self.hfile.file.filename}, obj: {self.hfile.name}, "
+                            f"max_chunksize: {self.hdf5zarr.max_chunksize}  :").rjust(len(request.node.nodeid)), end = '')
 
     ##########################################
     #  basic tests                           #
     ##########################################
-
-    @pytest.mark.parametrize('visit_type', [None], ids=[""])
-    def test_open_as_zarr(self):
-        zgroup = open_as_zarr(self.hfile)
-        assert zgroup.store == self.zgroup.store
-        assert zgroup == self.zgroup
 
     @pytest.mark.parametrize('visit_type', [None], ids=[""])
     def test_consolidate_metadata(self):
@@ -231,13 +243,6 @@ class HDF5ZarrBase(object):
                 assert_array_equal(zattr, hattr)
         self._visit_item(_test_read_attrs)
 
-    @pytest.fixture(autouse=True)
-    def visit_files(self, request):
-        # file number
-        fnum = request.node.callspec.params['fnum']
-        self.hfile, self.hdf5zarr = self.file_list[fnum], self.hdf5zarr_list[fnum]
-        self.zgroup = self.hdf5zarr.zgroup
-
     # visit hdf5 items
     # visit types, objects or links
     @pytest.fixture(autouse=True, params=["objects_only", "links_only"])
@@ -246,6 +251,7 @@ class HDF5ZarrBase(object):
 
         # collect flag
         self.fkeep = request.config.getoption("fkeep")
+        self.objnames = request.config.getoption("objnames")
 
         self._ex = []
 
@@ -329,6 +335,9 @@ class HDF5ZarrBase(object):
             h5py.h5o.visit(self.hfile.id, _test_obj, info=True)
         else:
             for name in self.objnames:
+                # skip objnames for subgroups
+                if not isinstance(self.hfile, h5py.File) or name not in self.hfile:
+                    continue
                 hobj_info = h5py.h5g.get_objinfo(self.hfile[name].id)
                 _test_obj(name, hobj_info)
 
@@ -377,6 +386,9 @@ class HDF5ZarrBase(object):
                 _test_obj(name, hlink_info)
         else:
             for name in self.objnames:
+                # skip objnames for subgroups
+                if not isinstance(self.hfile, h5py.File) or name not in self.hfile:
+                    continue
                 hlink_info = self.hfile.id.links.get_info(name)
                 _test_obj(name, hlink_info)
 
@@ -398,10 +410,18 @@ class HDF5ZarrBase(object):
                     any([dset_type.get_member_class(i) == h5py.h5t.REFERENCE for i in range(dset_type.get_nmembers())]))
 
 
-class TestHDF5Zarr(HDF5ZarrBase):
+class HDF5ZarrBase(object):
     """ Comparing HDF5Zarr read with h5py """
 
-    @classmethod
+    def __init__(self, hdf5files_option, hdf5file_names, ids_subgroup, ids_dset, ids_maxchunksize, _testfilename):
+        self.hdf5files_option = hdf5files_option
+        self.hdf5file_names = hdf5file_names
+        self.ids_subgroup = ids_subgroup
+        self.ids_dset = ids_dset
+        self.ids_maxchunksize = ids_maxchunksize
+        self._testfilename = _testfilename
+        self.setup_class()
+
     def setup_class(cls):
         # list of numpy dtypes up to 8 bytes
         cls.attribute_dtypes = list(set(np.typeDict.values()) -
@@ -459,52 +479,59 @@ class TestHDF5Zarr(HDF5ZarrBase):
         # do not save "_testfile"
         cls.fnum_keep[0] = True
 
-        group_names = []
-        dset_names = []
-        def _get_objs(name, info):
-            nonlocal group_names, dset_names
-            if info.type == h5py.h5o.TYPE_GROUP:
-                group_names.append(name.decode('utf-8'))
-            elif info.type == h5py.h5o.TYPE_DATASET:
-                dset_names.append(name.decode('utf-8'))
+        if cls.ids_subgroup or cls.ids_dset:
+            group_names = []
+            dset_names = []
+            def _get_objs(name, info):
+                nonlocal group_names, dset_names
+                if info.type == h5py.h5o.TYPE_GROUP:
+                    group_names.append(name.decode('utf-8'))
+                elif info.type == h5py.h5o.TYPE_DATASET:
+                    dset_names.append(name.decode('utf-8'))
 
-        if cls.numsubgroup != 0:
-            # len(cls.ids_subgroup) == num_files*cls.numsubgroup
-            cls.file_list += cls.file_list[:num_files]*cls.numsubgroup
-            cls.hdf5zarr_list += [None]*num_files*cls.numsubgroup
-            for i in range(num_files, num_files*(1+cls.numsubgroup)):
+            grnames = []
+            dsnames = []
+            for i in range(num_files):
                 group_names = []
                 dset_names = []
                 h5py.h5o.visit(cls.file_list[i].id, _get_objs, info=True)
-                group_names.sort()
-                dset_names.sort()
-                obj_names = [_objname for _objname in itertools.chain(*itertools.zip_longest(group_names, dset_names))
-                             if _objname is not None]  # interleave groups and dsets
-                if len(obj_names) != 0:
-                    # select next group in sorted group names
-                    hdf5group = obj_names[(i-num_files)//num_files if len(obj_names) > (i-num_files)//num_files else -1]
-                else:
-                    hdf5group = None
-                cls.hdf5zarr_list[i] = HDF5Zarr(cls.file_list[i].filename, hdf5group=hdf5group)
-                cls.file_list[i] = cls.file_list[i][hdf5group or '/']
+                grnames.append(group_names)
+                dsnames.append(dset_names)
 
-        if not cls.disable_max_chunksize:
-            # len(cls.ids_maxchunksize) == num_files*int(not disable_max_chunksize)*cls.num_maxchunksize
-            cls.file_list += cls.file_list[:num_files]*2
-            cls.hdf5zarr_list += [None]*num_files*2
-            for i in range(len(cls.file_list)-2*num_files, len(cls.file_list)-num_files):
-                max_chunksize = 1000 if not cls.hdf5files_option else 2**cls.srand.randint(14, 20)
-                cls.hdf5zarr_list[i] = HDF5Zarr(cls.file_list[i].filename, max_chunksize=max_chunksize)
-            for i in range(len(cls.file_list)-num_files, len(cls.file_list)):
-                max_chunksize = 2**cls.srand.randint(10, 20) if not cls.hdf5files_option else 2**cls.srand.randint(14, 20)
-                cls.hdf5zarr_list[i] = HDF5Zarr(cls.file_list[i].filename, max_chunksize=max_chunksize)
+        # len(cls.ids_subgroup) == num_files*cls.numsubgroup
+        for i in range(len(cls.ids_subgroup)):
+            group_names = grnames[i%num_files]
+            file_item = cls.file_list[i%num_files]
+            if len(group_names) != 0:
+                # select next group in sorted group names
+                hdf5group = group_names[i//num_files if len(group_names) > i//num_files else -1]
+            else:
+                hdf5group = None
+            cls.hdf5zarr_list.append(HDF5Zarr(file_item.filename, hdf5group=hdf5group))
+            cls.file_list.append(file_item[hdf5group or '/'])
 
-    @classmethod
-    def teardown_class(cls):
-        for f in cls.file_list[:cls.num_files]:
-            f.file.close()
+        # len(cls.ids_datasets) == num_files*cls.numdatasets
+        for i in range(len(cls.ids_dset)):
+            dset_names = dsnames[i%num_files]
+            file_item = cls.file_list[i%num_files]
+            if len(dset_names) != 0:
+                # select next dataset in sorted dataset names
+                hdf5obj = dset_names[i//num_files if len(dset_names) > i//num_files else -1]
+            else:
+                hdf5obj = None
+            cls.hdf5zarr_list.append(HDF5Zarr(file_item.filename, hdf5obj=hdf5obj))
+            cls.file_list.append(file_item[hdf5obj or '/'])
 
-    @classmethod
+        # len(cls.ids_maxchunksize) == (num_files+num_files*cls.numsubgroup+cls.numdatasets)*cls.num_maxchunksize
+        count = len(cls.hdf5zarr_list)  # number of hdf5zarr objects created in previous steps
+        for i in range(len(cls.ids_maxchunksize)):
+            # using same group/dataset names as in subgroups and datasets without max_chunksize
+            item_name = cls.hdf5zarr_list[i%count].zgroup.name
+            file_item = cls.file_list[i%count]
+            max_chunksize = 1000 if not cls.hdf5files_option else 2**cls.srand.randint(18, 22)
+            cls.hdf5zarr_list.append(HDF5Zarr(file_item.file.filename, hdf5obj=item_name, max_chunksize=max_chunksize))
+            cls.file_list.append(file_item)
+
     def _create_file(cls, name):
         """ create test hdf5 file """
 
@@ -814,7 +841,6 @@ class TestHDF5Zarr(HDF5ZarrBase):
 
         return hfile
 
-    @classmethod
     def _testfile(cls):
         """ create test hdf5 file """
 

--- a/tests/test_open_as_zarr.py
+++ b/tests/test_open_as_zarr.py
@@ -1,0 +1,118 @@
+from numpy.testing import assert_array_equal
+import numpy as np
+import h5py
+from hdf5zarr import open_as_zarr
+import pytest
+
+
+class Test_open_as_zarr_dset(object):
+    """ independently test open_as_zarr with h5py.Dataset as filename argument """
+
+    def test_open_as_zarr_dset_values(self, request, capsys, filesbase):
+        # get list of files passes by hdf5files arg
+        # if hdf5files is not specified, file_list will contain generated hdf5 files
+        num_files = filesbase.num_files
+        file_list = filesbase.file_list[0:num_files]
+
+        # find list of datasets in files
+        if len(self.objnames) != 0:
+            dset_list = [f[name] for name in self.objnames for f in file_list if (name in f and isinstance(f[name], h5py.Dataset))]
+            if len(dset_list) == 0:
+                message = f"No given file contains {self.objnames}"
+                with capsys.disabled():
+                    print("\n"+message.rjust(len(request.node.nodeid)), end='')
+                pytest.skip(message)
+        # if objnames arg is not passed, select datasets for each file
+        else:
+            numdset = request.config.getoption('numdataset')
+            if numdset <= 0:
+                pytest.skip(f"numdataset: {numdset}")
+
+            dset_names = []
+
+            def _get_dsets(name, info):
+                nonlocal dset_names
+                if info.type == h5py.h5o.TYPE_DATASET:
+                    dset_names.append(name.decode('utf-8'))
+
+            dset_list = []
+            for hfile in file_list:
+                dset_names = []
+                h5py.h5o.visit(hfile.id, _get_dsets, info=True)
+                names = dset_names[0:numdset]
+                for name in names:
+                    dset_list.append(hfile[name])
+                    message = f"objnames not specified. open_as_zarr run with file: {hfile.filename}, dataset: {name}"
+                    with capsys.disabled():
+                        print("\n"+message.rjust(len(request.node.nodeid)), end='')
+
+        for dset in dset_list:
+            with capsys.disabled():
+                print("\n"+f"file: {dset.file.filename}, dataset: {dset}  :".rjust(len(request.node.nodeid)), end='')
+                print("\n"+f"dataset: {dset.name}, data  :".rjust(len(request.node.nodeid)), end='')
+
+            # call open_as_zarr
+            if not dset.dtype.hasobject:
+                zarray = open_as_zarr(dset)  # dataset does not have object references
+            else:
+                zarray = open_as_zarr(dset, collectrefs=True)  # dataset with object references
+
+            # test values when dtype is variable length
+            if h5py.check_vlen_dtype(dset.dtype) is not None:
+                dset_str = dset.asstr()  # wrapper to read data as python str
+                assert_array_equal(dset_str, zarray)
+            # test values when dtype is structured array with object reference
+            elif dset.dtype.hasobject and dset.dtype.names is not None:
+                hval = dset[()]
+                # function to get reference target names
+                ref_array_func = np.frompyfunc(lambda x: h5py.h5i.get_name(h5py.h5r.dereference(x, dset.file.id)), 1, 1)
+                for dtname in dset.dtype.names:
+                    if dset.dtype[dtname].hasobject:
+                        if dset.shape != ():
+                            hval_str = ref_array_func(hval[dtname]).astype(str)
+                        else:
+                            hval_str = h5py.h5i.get_name(h5py.h5r.dereference(hval[dtname], dset.file.id))
+                            hval_str = hval_str.decode('utf-8')
+                        assert_array_equal(hval_str, zarray[dtname])
+            # test values when dtype is object reference
+            elif dset.dtype.hasobject and dset.dtype.names is None:
+                hval = dset[()]
+                # function to get reference target names
+                ref_array_func = np.frompyfunc(lambda x: h5py.h5i.get_name(h5py.h5r.dereference(x, dset.file.id)), 1, 1)
+                if dset.shape != ():
+                    hval_str = ref_array_func(hval).astype(str)
+                else:
+                    hval_str = h5py.h5i.get_name(h5py.h5r.dereference(hval, dset.file.id))
+                    hval_str = hval_str.decode('utf-8')
+                assert_array_equal(hval_str, zarray)
+            # test values when dtype is simple
+            else:
+                assert_array_equal(dset, zarray)
+
+            with capsys.disabled():
+                print("\n"+f"dataset: {dset.name}, attrs  :".rjust(len(request.node.nodeid)), end='')
+
+            # test attrs
+            for key, val in dset.attrs.items():
+                assert_array_equal(val, zarray.attrs[key])
+
+            with capsys.disabled():
+                print("\n"+f"dataset: {dset.name}, fillvalue  :".rjust(len(request.node.nodeid)), end='')
+
+            # test fillvalue
+            # if dtype is structured array
+            if dset.fillvalue is not None and dset.fillvalue.dtype.names is not None:
+                if dset.fillvalue.dtype.hasobject:
+                    message = f"structured array fillvalue {dset.fillvalue} with object dtype not supported."
+                    with capsys.disabled():
+                        print(("\n"+message).rjust(len(request.node.nodeid)), end='')
+                    pytest.xfail(reason=message)
+                assert_array_equal(dset.fill_value, zarray.fillvalue)
+            # if fillvalue is an object reference:
+            elif dset.fillvalue is not None and dset.fillvalue.dtype.hasobject:
+                hval_str = h5py.h5i.get_name(h5py.h5r.dereference(dset.fillvalue, dset.file.id))
+                hval_str = hval_str.decode('utf-8')
+                assert_array_equal(hval_str, zarray.fill_value)
+            # simple fillvalue
+            else:
+                assert_array_equal(dset.fillvalue, zarray.fill_value)

--- a/tests/test_open_as_zarr.py
+++ b/tests/test_open_as_zarr.py
@@ -4,6 +4,7 @@ import h5py
 from hdf5zarr import open_as_zarr
 import pytest
 import fsspec
+import zarr
 
 
 class Test_open_as_zarr_dset(object):
@@ -135,6 +136,7 @@ class Test_open_as_zarr_dset(object):
             print("\n"+f"dataset: {dsetname}, data  :".rjust(len(request.node.nodeid)), end='')
 
         zarray = open_as_zarr(dset)  # dataset does not have object references
+        assert isinstance(zarray, zarr.Array)
 
         # test simple dtype
         assert_array_equal(dset, zarray)


### PR DESCRIPTION
adds `open_as_zarr` and `export_to_zarr` functions. allow passing `h5py.Group`, `h5py.Dataset` or url as filename.
adds 'hdf5obj' string argument to restrict metadata to objects in given hdf5 path.
allow setting `collectattrs` argument to skip attributes.
adds `blocksize` argument to HDF5Zarr used while building the metadata zarr store, in case remote file-like object is already using a large blocksize.
fixes performance issues with variable-length datasets, and removes early reading of hdf5 object addresses.